### PR TITLE
Update dependencies versions and add warning for maven artefacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 Java library for Aserto services
 
-
+> **Warning**
+> 
+> **0.20.5** is the latest version published to maven central. Versions starting with 1.0.z have been removed from maven central and are no longer available for download.
 
 ### Build
 `mvn clean install`
@@ -14,7 +16,7 @@ Java library for Aserto services
 <dependency>
     <groupId>com.aserto</groupId>
     <artifactId>aserto-java</artifactId>
-    <version>1.0.0</version>
+    <version>0.20.5</version>
 </dependency>
 ```
 

--- a/examples/authz-example/README.md
+++ b/examples/authz-example/README.md
@@ -61,5 +61,5 @@ cp assets/.env.topaz-authorizer.example .env
 To run the examples, execute:
 
 ```bash
-java -jar target/examples-1.0.0-SNAPSHOT-shaded.jar
+java -jar target/examples-1.0.0-shaded.jar
 ```

--- a/examples/authz-example/pom.xml
+++ b/examples/authz-example/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.aserto</groupId>
             <artifactId>aserto-java</artifactId>
-            <version>1.0.1</version>
+            <version>0.20.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Versions starting with 1.0.z have been removed from maven central, but they still appear in the search https://central.sonatype.com/artifact/com.aserto/aserto-java
If a user tries to use 1.0.z version, they will get an error, because the artifact is not available for download. In order to reduce the confusion I added a warning message in the readme.