### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 17
           distribution: temurin
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.aserto</groupId>
     <artifactId>aserto-java</artifactId>
-    <version>0.20.10</version>
+    <version>0.20.11</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Java SDK to interact with aserto services</description>


### PR DESCRIPTION
The [last release failed](https://github.com/aserto-dev/aserto-java/actions/runs/7035055621) because the release CI was using Java 8 but the project requires Java 17. This PR fixes the CI to use Java 17.